### PR TITLE
Add session filters

### DIFF
--- a/src/actions/term.actions.ts
+++ b/src/actions/term.actions.ts
@@ -1,3 +1,5 @@
+'use server';
+
 import { campusFetch } from '@/lib/client';
 import { Term } from '@/types/models/term';
 

--- a/src/app/[locale]/(private)/module/vedomoststud/components/session-filters.tsx
+++ b/src/app/[locale]/(private)/module/vedomoststud/components/session-filters.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React from 'react';
+import { Paragraph } from '@/components/typography/paragraph';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useTranslations } from 'next-intl';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Semester } from '@/types/enums/current-control/semester';
+
+interface Props {
+  selectedSemester?: Semester;
+  selectedStudyYear?: string;
+  currentYear: string;
+  studyYears: string[];
+  onStudyYearSelect: (value?: string) => void;
+  onSemesterSelect: (value?: Semester) => void;
+}
+
+export function SessionFilters({
+  currentYear,
+  studyYears,
+  selectedSemester,
+  selectedStudyYear,
+  onStudyYearSelect,
+  onSemesterSelect,
+}: Props) {
+  const t = useTranslations('private.study-sheet');
+  const tSemester = useTranslations('private.study-sheet.semester');
+
+  return (
+    <>
+      <div className="flex items-center">
+        <Paragraph className="mr-5 text-lg font-semibold text-neutral-700">{t('study-year')}</Paragraph>
+        <Select value={selectedStudyYear} onValueChange={onStudyYearSelect}>
+          <SelectTrigger className="h-[36px] w-[132px]">
+            <SelectValue placeholder={currentYear} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {studyYears.map((year) => (
+                <SelectItem key={year} value={year}>
+                  {year}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="flex items-center gap-4">
+        <Paragraph className="text-lg font-semibold text-neutral-700 lg:ml-4">{tSemester('title')}</Paragraph>
+        <Tabs
+          defaultValue="all"
+          value={selectedSemester}
+          onValueChange={(value) => onSemesterSelect(value as Semester)}
+          className="w-[210px]"
+        >
+          <TabsList className="p-[2px]" size="small">
+            <TabsTrigger className="w-[55px] md:w-[66px]" value={Semester.All}>
+              {tSemester('all')}
+            </TabsTrigger>
+            <TabsTrigger className="w-[60px] md:w-[66px]" value={Semester.First}>
+              {tSemester('first')}
+            </TabsTrigger>
+            <TabsTrigger className="w-[60px] md:w-[66px]" value={Semester.Second}>
+              {tSemester('second')}
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+    </>
+  );
+}

--- a/src/app/[locale]/(private)/module/vedomoststud/components/session.tsx
+++ b/src/app/[locale]/(private)/module/vedomoststud/components/session.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useTranslations } from 'next-intl';
+import { dash } from 'radash';
+import { getTerm } from '@/actions/term.actions';
+import { Term, TermDiscipline } from '@/types/models/term';
+import { Semester } from '@/types/enums/current-control/semester';
+import { useLocalStorage } from '@/hooks/use-storage';
+import { useServerErrorToast } from '@/hooks/use-server-error-toast';
+import SpinnerGap from '@/app/images/icons/SpinnerGap.svg';
+import { round } from '@/lib/utils';
+import { SessionFilters } from './session-filters';
+import { TermStatusBadge } from './term-status-badge';
+import { ProfilePicture } from '@/components/ui/profile-picture';
+
+const MAX_SCORE = 100;
+
+export function Session() {
+  const t = useTranslations('private.vedomoststud');
+  const tEnums = useTranslations('global.enums');
+
+  const [term, setTerm] = useState<Term | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const { errorToast } = useServerErrorToast();
+
+  const fetchData = useCallback(async () => {
+    try {
+      const data = await getTerm();
+      setTerm(data);
+    } catch (error) {
+      errorToast();
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const disciplines: TermDiscipline[] = term?.disciplines ?? [];
+
+  const studyYears = useMemo(() => {
+    const years = new Set<string>();
+    disciplines.forEach((d) => {
+      if ((d as any).studyYear) {
+        years.add((d as any).studyYear as string);
+      }
+    });
+    return Array.from(years);
+  }, [disciplines]);
+
+  const currentYear = studyYears.at(-1) || '';
+
+  const [selectedStudyYear = currentYear, setSelectedStudyYear] = useLocalStorage<string>('termStudyYear');
+  const [selectedSemester = Semester.All, setSelectedSemester] = useLocalStorage<Semester>('termSemester');
+
+  const filteredDisciplines = useMemo(() => {
+    return disciplines.filter((d) => {
+      const matchesYear = !selectedStudyYear || (d as any).studyYear === selectedStudyYear;
+      const matchesSemester =
+        selectedSemester === Semester.All || String((d as any).semester) === selectedSemester;
+      return matchesYear && matchesSemester;
+    });
+  }, [disciplines, selectedSemester, selectedStudyYear]);
+
+  const averageScore = useMemo(() => {
+    const marks = filteredDisciplines.map((d) => d.mark).filter((m): m is number => m !== undefined);
+    if (!marks.length) return 0;
+    const total = marks.reduce((acc, m) => acc + m, 0);
+    return round(total / marks.length, 2);
+  }, [filteredDisciplines]);
+
+  const LecturerItem = ({ photo, fullName }: { photo: string; fullName: string }) => (
+    <div className="flex items-center gap-3">
+      <ProfilePicture size="xs" src={photo} />
+      <span className="text-sm font-semibold text-basic-black">{fullName}</span>
+    </div>
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <SpinnerGap />
+      </div>
+    );
+  }
+
+  return (
+    <Card className="rounded-b-6 col-span-full w-full bg-white p-6 xl:col-span-5">
+      <div className="mb-4 flex flex-col lg:flex-row lg:items-center">
+        <SessionFilters
+          studyYears={studyYears}
+          currentYear={currentYear}
+          selectedSemester={selectedSemester}
+          selectedStudyYear={selectedStudyYear}
+          onStudyYearSelect={setSelectedStudyYear}
+          onSemesterSelect={setSelectedSemester}
+        />
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>{t('date')}</TableHead>
+            <TableHead>{t('subject')}</TableHead>
+            <TableHead className="text-center">{t('score')}</TableHead>
+            <TableHead>{t('controlType')}</TableHead>
+            <TableHead>{t('sessionType')}</TableHead>
+            <TableHead>{t('lecturer')}</TableHead>
+            <TableHead>{t('status')}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filteredDisciplines.map((row, index) => (
+            <TableRow key={index}>
+              <TableCell className="w-[120px]">{row.date}</TableCell>
+              <TableCell className="w-[300px]">{row.name}</TableCell>
+              <TableCell className="w-[109px] text-center">
+                {row.mark !== undefined && (
+                  <Badge className="font-semibold text-basic-blue">
+                    {Number(row.mark)}/{MAX_SCORE}
+                  </Badge>
+                )}
+              </TableCell>
+              <TableCell className="w-[140px]">{tEnums(`assessment-type.${dash(row.assessmentType)}`)}</TableCell>
+              <TableCell className="w-[140px]">{tEnums(`record-type.${dash(row.recordType)}`)}</TableCell>
+              <TableCell className="max-w-[158px]">
+                {row.lecturer && <LecturerItem photo={row.lecturer.photo} fullName={row.lecturer.fullName} />}
+              </TableCell>
+              <TableCell className="w-[140px]">
+                <TermStatusBadge className="flex justify-center border text-center font-semibold" status={row.status} />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <div className="my-2 flex items-center gap-2 whitespace-nowrap pl-4">
+        <p className="text-base font-normal">{t('average-score')}</p>
+        <Badge className="bg-basic-blue font-semibold text-basic-white">{averageScore}</Badge>
+      </div>
+    </Card>
+  );
+}

--- a/src/app/[locale]/(private)/module/vedomoststud/components/term-status-badge.tsx
+++ b/src/app/[locale]/(private)/module/vedomoststud/components/term-status-badge.tsx
@@ -1,5 +1,7 @@
+'use client';
+
 import { Badge } from '@/components/ui/badge';
-import { getTranslations } from 'next-intl/server';
+import { useTranslations } from 'next-intl';
 import { dash } from 'radash';
 import { Status } from '@/types/enums/session/status';
 import { cn } from '@/lib/utils';
@@ -10,8 +12,8 @@ interface TermStatusBadgeProps {
   className?: string;
 }
 
-export async function TermStatusBadge({ status, className }: TermStatusBadgeProps) {
-  const tEnums = await getTranslations('global.enums');
+export function TermStatusBadge({ status, className }: TermStatusBadgeProps) {
+  const tEnums = useTranslations('global.enums');
   const label = tEnums(`status.${dash(status)}`);
   const statusStyle = getStatusStyle(status);
 

--- a/src/app/[locale]/(private)/module/vedomoststud/page.tsx
+++ b/src/app/[locale]/(private)/module/vedomoststud/page.tsx
@@ -1,15 +1,8 @@
 import { getTranslations } from 'next-intl/server';
 import React from 'react';
-import { dash } from 'radash';
 
-import { getTerm } from '@/actions/term.actions';
-import { LecturerItemCell } from '@/app/[locale]/(private)/module/studysheet/[id]/components/lecturer-item-cell';
-import { Badge } from '@/components/ui/badge';
-import { Card } from '@/components/ui/card';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { LocaleProps } from '@/types/locale-props';
-import { TermStatusBadge } from '@/app/[locale]/(private)/module/vedomoststud/components/term-status-badge';
-import { Paragraph } from '@/components/typography';
+import { Session } from '@/app/[locale]/(private)/module/vedomoststud/components/session';
 
 const INTL_NAMESPACE = 'private.vedomoststud';
 
@@ -23,56 +16,6 @@ export async function generateMetadata({ params }: LocaleProps) {
   };
 }
 
-const MAX_SCORE = 100;
-
 export default async function SessionPage() {
-  const t = await getTranslations(INTL_NAMESPACE);
-  const tEnums = await getTranslations('global.enums');
-
-  const termResults = await getTerm();
-
-  return (
-    <Card className="rounded-b-6 col-span-full w-full bg-white p-6 xl:col-span-5">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>{t('date')}</TableHead>
-            <TableHead>{t('subject')}</TableHead>
-            <TableHead className="text-center">{t('score')}</TableHead>
-            <TableHead>{t('controlType')}</TableHead>
-            <TableHead>{t('sessionType')}</TableHead>
-            <TableHead>{t('lecturer')}</TableHead>
-            <TableHead>{t('status')}</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {termResults.disciplines.map((row, index) => (
-            <TableRow key={index}>
-              <TableCell className="w-[120px]">{row.date}</TableCell>
-              <TableCell className="w-[300px]">{row.name}</TableCell>
-              <TableCell className="w-[109px] text-center">
-                {row.mark && (
-                  <Badge className="font-semibold text-basic-blue">
-                    {Number(row.mark)}/{MAX_SCORE}
-                  </Badge>
-                )}
-              </TableCell>
-              <TableCell className="w-[140px]">{tEnums(`assessment-type.${dash(row.assessmentType)}`)}</TableCell>
-              <TableCell className="w-[140px]">{tEnums(`record-type.${dash(row.recordType)}`)}</TableCell>
-              <TableCell className="max-w-[158px]">
-                {row.lecturer && <LecturerItemCell photo={row.lecturer.photo} fullName={row.lecturer.fullName} />}
-              </TableCell>
-              <TableCell className="w-[140px]">
-                <TermStatusBadge className="flex justify-center border text-center font-semibold" status={row.status} />
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-      <div className="my-2 flex items-center gap-2 whitespace-nowrap pl-4">
-        <Paragraph className="text-base font-normal">{t('average-score')}</Paragraph>
-        <Badge className="bg-basic-blue font-semibold text-basic-white">{termResults.averageScore}</Badge>
-      </div>
-    </Card>
-  );
+  return <Session />;
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -438,7 +438,7 @@
       "sessionType": "Session order type",
       "lecturer": "Lecturer",
       "status": "Status",
-      "average-score": "Average score for the entire period of study:"
+      "average-score": "Average score:"
     },
     "study-sheet": {
       "title": "Current control",

--- a/src/messages/uk.json
+++ b/src/messages/uk.json
@@ -438,7 +438,7 @@
       "sessionType": "Тип відомості",
       "lecturer": "Викладач",
       "status": "Статус",
-      "average-score": "Середній бал за весь період навчання:"
+      "average-score": "Середній бал:"
     },
     "study-sheet": {
       "title": "Поточний контроль",

--- a/src/types/models/term.ts
+++ b/src/types/models/term.ts
@@ -6,6 +6,8 @@ import { Lecturer } from './lecturer';
 export interface TermDiscipline {
   name: string;
   mark?: number;
+  studyYear?: string;
+  semester?: number;
   assessmentType: AssessmentType;
   recordType: RecordType;
   date?: string;


### PR DESCRIPTION
## Summary
- show a Session component with year/semester filters
- calculate average score based on selected filters
- refactor term status badge for client use
- support study year/semester in term models
- tweak translations for average score

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68658d22754c83318d88d2ae2d45cb12